### PR TITLE
Remove npm install -g npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN apt-get update && apt-get install -y ruby ruby-dev ruby-bundler python-softw
 # Nodejs
 RUN curl --silent --location https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get update && apt-get install nodejs -y
-RUN npm install -g npm@3
 
 RUN wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz


### PR DESCRIPTION
This causes https://github.com/npm/npm/issues/9863
We now get npm@3 when we do apt-get install nodejs
